### PR TITLE
Do not escape backslash in String

### DIFF
--- a/alf-api/src/main/java/io/axway/alf/formatter/JsonWriter.java
+++ b/alf-api/src/main/java/io/axway/alf/formatter/JsonWriter.java
@@ -124,7 +124,7 @@ public final class JsonWriter implements Arguments {
                         m_sb.append("\\u").append(codePoint, codePoint.length() - 4, 4);
                         break;
                 }
-            } else if (c == '"' || c == '\\') {
+            } else if (c == '"') {
                 m_sb.append('\\').append(c);
             } else {
                 m_sb.append(c);

--- a/alf-api/src/test/java/io/axway/alf/formatter/JsonMessageFormatterTest.java
+++ b/alf-api/src/test/java/io/axway/alf/formatter/JsonMessageFormatterTest.java
@@ -1,5 +1,6 @@
 package io.axway.alf.formatter;
 
+import java.nio.file.Paths;
 import org.testng.annotations.Test;
 
 import static io.axway.alf.formatter.JsonMessageFormatter.getFormatter;
@@ -105,5 +106,17 @@ public class JsonMessageFormatterTest {
                                                new IllegalStateException("Kaboom"));
         assertThat(message).isEqualTo("myMessage {\"args\": {\"string\": \"foo\", \"int\": 42, \"nested\": {\"key\": \"value\"}}, "
                                               + "\"exception\": {\"type\": \"java.lang.IllegalStateException\", \"message\": \"Kaboom\"}}");
+    }
+
+    @Test
+    public void testFormatWithBackslash() {
+        String message = getFormatter().format("myMessage", a -> a.add("myKey", "\\myValue"));
+        assertThat(message).isEqualTo("myMessage {\"args\": {\"myKey\": \"\\myValue\"}}");
+    }
+
+    @Test
+    public void testFormatWithPath() {
+        String message = getFormatter().format("myMessage", a -> a.add("myKey", Paths.get("root", "child")));
+        assertThat(message).isEqualTo("myMessage {\"args\": {\"myKey\": \"root\\child\"}}");
     }
 }


### PR DESCRIPTION
Do not escape backslash in Json string as it is not required to produce a valid json.
Escaping them make path display a bit hard to read like `S:\\root\\child1\\child2\\child3\\file`.